### PR TITLE
fix readAsnInteger for integers which are 128 bytes and longer

### DIFF
--- a/src/main/java/com/github/fommil/ssh/SshRsaCrypto.java
+++ b/src/main/java/com/github/fommil/ssh/SshRsaCrypto.java
@@ -34,8 +34,9 @@ public class SshRsaCrypto {
         checkArgument(in.read() == 2, "no INTEGER marker");
         int length = in.read();
         if (length >= 0x80) {
-            byte[] extended = new byte[length & 0x7f];
-            in.readFully(extended);
+            byte[] extended = new byte[4];
+            int bytesToRead = length & 0x7f;
+            in.readFully(extended, 4 - bytesToRead, bytesToRead);
             length = new BigInteger(extended).intValue();
         }
         byte[] data = new byte[length];


### PR DESCRIPTION
if block of bytes is [2, -127, -127, ... ] then
2 - means that it's integer
-127 - means that lenght is more than 0x80. read next byte(s) to get actual length (bytesToRead = -127 & 0x7f = 1)
next byte is -127 - means that lenght is 129  integer from byte[] {0,0,0,-127}
but old code return length=-127 becaues it does not put three leading 0 in byte[] representing length - new BigInteger(new byte[]{-127})
correct value should be integer from byte[]{0,0,0,-127} - which is 129 - new BigInteger(new byte[] {0,0,0,-127})